### PR TITLE
Support fallback to dynamic shape inference, add more op

### DIFF
--- a/nn_meter/ir_converters/frozenpb_converter/frozenpb_converter.py
+++ b/nn_meter/ir_converters/frozenpb_converter/frozenpb_converter.py
@@ -5,7 +5,7 @@ import numpy as np
 from nn_meter.utils.graph_tool import ModelGraph
 from .frozenpb_parser import FrozenPbParser
 from .shape_inference import ShapeInference
-
+from .shape_fetcher import ShapeFetcher
 
 class FrozenPbConverter:
     def __init__(self, file_name):
@@ -14,12 +14,13 @@ class FrozenPbConverter:
         # Parse pb to graph
         parser = FrozenPbParser(file_name)
         parser.parse_graph(self.model_graph)
+        dynamic_fetcher = ShapeFetcher(parser.graph)
 
         # Change split to more firendly scheme
         parser.fix_split_naming(self.model_graph)
 
         # Get the static shape
-        ShapeInference(self.model_graph)
+        ShapeInference(self.model_graph, dynamic_fetcher)
 
         # Strip constant and indentity nodes
         parser.strip_useless_nodes(self.model_graph)

--- a/nn_meter/ir_converters/frozenpb_converter/frozenpb_parser.py
+++ b/nn_meter/ir_converters/frozenpb_converter/frozenpb_parser.py
@@ -14,7 +14,7 @@ class FrozenPbParser:
     def __init__(self, pb_file):
         tf = try_import_tensorflow()
         f = open(pb_file, "rb")
-        graph = tf.GraphDef()
+        graph = tf.compat.v1.GraphDef()
         graph.ParseFromString(f.read())
 
         self.graph = graph
@@ -233,7 +233,7 @@ class FrozenPbParser:
 
         return attr_dict
 
-    def parse_graph(self, model_graph, required_shape=False):
+    def parse_graph(self, model_graph):
         """
         Parse a frozen protobuf file from tensorflow to graph IR
 
@@ -241,11 +241,7 @@ class FrozenPbParser:
         ----------
         model_graph : ModelGraph
             The Graph IR holder.
-        required_shape : bool
-            Using dynamic shape inference to fetch the tensor shape.
         """
-        if required_shape:
-            shape_fetcher = ShapeFetcher(self.graph)
 
         for node in self.graph.node:
             model_graph.node(str(node.name), list(map(str, node.input)))
@@ -254,9 +250,7 @@ class FrozenPbParser:
                 {
                     "name": str(node.name),
                     "type": str(node.op),
-                    "output_shape": shape_fetcher.shape_results[node.name + ":0"]
-                    if required_shape
-                    else [],
+                    "output_shape": [], # This will be filled later
                     "attr": self.fetch_attr_to_dict(node),
                 },
             )


### PR DESCRIPTION
0. Remove the full dynamic inference option from frozenpb_parser.py
1. Fallback using dynamic shape inference when encountering un-supported ops.
2. Add more general op supports.