### PR TITLE
<fix>: 'id' is a python keyword and will cause an unexpected error.

### DIFF
--- a/nn_meter/builder/kernel_predictor_builder/predictor_builder/extract_feature.py
+++ b/nn_meter/builder/kernel_predictor_builder/predictor_builder/extract_feature.py
@@ -164,15 +164,15 @@ def get_data_by_profiled_results(kernel_type, feature_parser, cfgs_path, labs_pa
         labs_dict = labs_path[kernel_type] if kernel_type in labs_path else labs_path
 
     paths, features, labs = [], [], []
-    for id in labs_dict.keys():
+    for idx in labs_dict.keys():
         try:
-            path = cfgs_dict[id]["model"]
-            configs = cfgs_dict[id]["config"]
+            path = cfgs_dict[idx]["model"]
+            configs = cfgs_dict[idx]["config"]
             feature = feature_parser.get_feature_by_config(configs)
             if predict_label == "latency":
-                label = labs_dict[id]["latency"].avg
+                label = labs_dict[idx]["latency"].avg
             else:
-                label = labs_dict[id][predict_label]
+                label = labs_dict[idx][predict_label]
             if label != 0.0:
                 paths.append(os.path.basename(path))
                 features.append(feature)

--- a/nn_meter/builder/nn_meter_builder.py
+++ b/nn_meter/builder/nn_meter_builder.py
@@ -41,7 +41,7 @@ def convert_models(backend, models, mode = 'predbuild', broken_point_mode = Fals
     # convert models
     count = 0
     for _, modules in models.items():
-        for id, model in modules.items():
+        for idx, model in modules.items():
             if broken_point_mode and 'converted_model' in model:
                 continue
             try:
@@ -49,7 +49,7 @@ def convert_models(backend, models, mode = 'predbuild', broken_point_mode = Fals
                 converted_model = backend.convert_model(model_path, model_save_path, model['shapes'])
                 model['converted_model'] = converted_model
             except Exception as e:
-                open(os.path.join(info_save_path, "convert_error.log"), 'a').write(f"{id}: {e}\n")
+                open(os.path.join(info_save_path, "convert_error.log"), 'a').write(f"{idx}: {e}\n")
 
             # save information to json file for per 50 models
             count += 1
@@ -104,7 +104,7 @@ def profile_models(backend, models, mode = 'ruletest', metrics = ["latency"], sa
     save_name = save_name or "profiled_results.json"
     logging.info("Profiling ...")
     for _, modules in models.items():
-        for id, model in modules.items():
+        for idx, model in modules.items():
             if have_converted: # the models have been converted for the backend
                 try:
                     model_path = model['converted_model']
@@ -114,7 +114,7 @@ def profile_models(backend, models, mode = 'ruletest', metrics = ["latency"], sa
                     time.sleep(0.2)
                     count += 1
                 except Exception as e:
-                    open(os.path.join(info_save_path, "profile_error.log"), 'a').write(f"{id}: {e}\n")
+                    open(os.path.join(info_save_path, "profile_error.log"), 'a').write(f"{idx}: {e}\n")
             else: # the models have not been converted
                 try:
                     model_path = model['model']
@@ -124,7 +124,7 @@ def profile_models(backend, models, mode = 'ruletest', metrics = ["latency"], sa
                     time.sleep(0.2)
                     count += 1
                 except Exception as e:
-                    open(os.path.join(info_save_path, "profile_error.log"), 'a').write(f"{id}: {e}\n")
+                    open(os.path.join(info_save_path, "profile_error.log"), 'a').write(f"{idx}: {e}\n")
 
             # save information to json file for per 50 models
             if count > 0 and count % 50 == 0:


### PR DESCRIPTION
Reproduce:
macbook pro
python 3.9
```bash
1. create tflite workspace
nn-meter create --tflite-workspace <path/to/workspace>
2. connect android device with usb (adb is ready)
3. download the fixed "benchmark_model" and push to device
4. run examples/nn-meter_builder_examples/build_kernel_latency_predictor.ipynb
```
nothing happens in stage "connect backend" and "parse profile resule", just throw an IndexError as follows, it is confused
```
(nn-Meter) All 0 models complete. Save all success profiled results to /Users/weixiaobin/Repos/arxiv/nn-Meter/ws-tflite/predictor_build/results/profiled_conv-bn-relu.json.
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Input In [4], in <cell line: 6>()
      3 kernel_type = "conv-bn-relu"
      4 backend = "tflite_cpu"
----> 6 predictor, data = build_predictor_for_kernel(
      7     kernel_type, backend, init_sample_num = 10, finegrained_sample_num = 10, iteration = 5, error_threshold = 0.1
      8 )

File ~/opt/anaconda3/envs/nnm/lib/python3.9/site-packages/nn_meter/builder/nn_meter_builder.py:190, in build_predictor_for_kernel(kernel_type, backend, init_sample_num, finegrained_sample_num, iteration, error_threshold, predict_label)
    187 kernel_data = sample_and_profile_kernel_data(kernel_type, init_sample_num, backend, sampling_mode='prior', mark='prior')
    189 # use current sampled data to build regression model, and locate data with large errors in testset
--> 190 predictor, acc10, error_configs = build_predictor_by_data(kernel_type, kernel_data, backend, error_threshold=error_threshold, mark='prior',
    191                                                           save_path=os.path.join(workspace_path, "results"), predict_label=predict_label)
    192 logging.keyinfo(f'Iteration 0: acc10 {acc10}, error_configs number: {len(error_configs)}')
    194 for i in range(1, iteration):
    195     # finegrained sampling and profiling for large error data

File ~/opt/anaconda3/envs/nnm/lib/python3.9/site-packages/nn_meter/builder/kernel_predictor_builder/predictor_builder/build_predictor.py:37, in build_predictor_by_data(kernel_type, kernel_data, backend, error_threshold, mark, save_path, predict_label)
     35 os.makedirs(os.path.join(save_path, "collection"), exist_ok=True)
     36 os.makedirs(os.path.join(save_path, "predictors"), exist_ok=True)
---> 37 data = get_data_by_profiled_results(kernel_type, feature_parser, kernel_data,
     38                                     save_path=os.path.join(save_path, "collection", f'Data_{kernel_type}_{mark}.csv'),
     39                                     predict_label=predict_label)
     41 # get data for regression
     42 X, Y = data

File ~/opt/anaconda3/envs/nnm/lib/python3.9/site-packages/nn_meter/builder/kernel_predictor_builder/predictor_builder/extract_feature.py:187, in get_data_by_profiled_results(kernel_type, feature_parser, cfgs_path, labs_path, save_path, predict_label)
    185 import pandas as pd
    186 cols = feature_parser.needed_config[:]
--> 187 if len(features[0]) - len(feature_parser.needed_config) > 0: # there are extra features beyond needed config
    188     cols += [f'feature_{i}' for i in range(len(features[0]) - len(feature_parser.needed_config))]
    189 data_df = pd.DataFrame(features, columns=cols)

IndexError: list index out of range
```