### PR TITLE
Fix errors for single-node graph

### DIFF
--- a/nn_meter/ir_converter/onnx_converter/converter.py
+++ b/nn_meter/ir_converter/onnx_converter/converter.py
@@ -16,7 +16,7 @@ class OnnxConverter:
         self.graph = inferred_model.graph
 
         self.tensors = {}
-        for tensor in chain(self.graph.input, self.graph.value_info, self.graph.output):
+        for tensor in chain(self.graph.input, self.graph.value_info, self.graph.initializer, self.graph.output):
             self.tensors[tensor.name] = {
                 "shape": get_tensor_shape(tensor),
                 "inputs": [],

--- a/nn_meter/ir_converter/onnx_converter/utils.py
+++ b/nn_meter/ir_converter/onnx_converter/utils.py
@@ -2,8 +2,12 @@
 # Licensed under the MIT license.
 def get_tensor_shape(tensor):
     shape = []
-    for dim in tensor.type.tensor_type.shape.dim:
-        shape.append(dim.dim_value)
+    try:
+        for dim in tensor.type.tensor_type.shape.dim:
+            shape.append(dim.dim_value)
+    except AttributeError:
+        # initializer
+        shape += tensor.dims
     if len(shape) == 4:
         shape = [shape[0], shape[2], shape[3], shape[1]]
     return shape

--- a/nn_meter/utils/graph_tool.py
+++ b/nn_meter/utils/graph_tool.py
@@ -28,6 +28,9 @@ class ModelGraph:
                 self.graph[node]["outbounds"].append(name)
 
     def refresh(self):
+        if len(self.graph) <= 1:
+            return
+
         last_remove_nodes_cnt = -1
         while True:
             for name in self.graph.keys():


### PR DESCRIPTION
This PR addresses some problems when the graph only contains one single node.

To reproduce this issue:

```python
from torch import nn
from nn_meter import load_latency_predictor

predictor = load_latency_predictor('cortexA76cpu_tflite21')
base_model = nn.Linear(3, 3)
lat = predictor.predict(model=base_model, model_type='torch', input_shape=[1, 3])
print(lat)
```

Two problems are hidden inside:

1. The graph has a special initializer in this case (which also has a different dims format). I'm not sure whether it's related to the specific single-node graph, or related to my PyTorch version (v1.12.1).
2. `refresh()` erroneously marked the single node as unused and deleted the node, making the result always 0.

Tests should be added for this case, but unfortunately I didn't find a seat for it in the currently testing framework, so I decided to leave it for now.
