### PR TITLE
Update extract_feature.py

### DIFF
--- a/nn_meter/predictor/prediction/extract_feature.py
+++ b/nn_meter/predictor/prediction/extract_feature.py
@@ -56,16 +56,18 @@ def get_predict_features(config):
         elif "concat" in op:  # maximum 4 branches
             itensors = item["input_tensors"]
             inputh = itensors[0][1]
-            features = [inputh, len(itensors)]
+            #features = [inputh, len(itensors)]
+            features = [inputh]
             for it in itensors:
-                co = it[-1]
+                #co = it[-1]
+                co = it[-2]
                 features.append(co)
-            if len(features) < 6:
-                features = features + [0] * (6 - len(features))
-            elif len(features) > 6:
-                nf = features[0:6]
+            if len(features) < 5:
+                features = features + [0] * (5 - len(features))
+            elif len(features) > 5:
+                nf = features[0:5]
                 features = nf
-                features[1] = 6
+                #features[1] = 5
         elif op in ["hswish"]:
             if "inputh" in item:
                 inputh = item["inputh"]


### PR DESCRIPTION
The feature set used to build the 'concat' predictor is [ HW, CIN1 , CIN2 , CIN3 , CIN4 ] but when we are predicting , the feature set is wrongly extracted for concat layer. The ' no. of input tensors ' feature value is not required in the feature list because we are adding padding values to the list if no. of tensors are less than 4 and removing extra tensors if no. of tensors more than 4 thus maintaining the consistency. Even no. of channels are wrongly extracted thus made changes accordingly.